### PR TITLE
Adds ability to set any parameter to notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ public function routeNotificationForOneSignal()
 - `webButton(OneSignalWebButton $button)`: Allows you to add action buttons to the notification (Chrome 48+ (web push) only).
 - `button(OneSignalButton $button)`: Allows you to add buttons to the notification (Supported by iOS 8.0 and Android 4.1+ devices. Icon only works for Android).
 - `setData($key, $value)`: Allows you to set additional data for the message payload. For more information check the [OneSignal documentation](https://documentation.onesignal.com/reference).
+- `setParameter($key, $value)`: Allows you to set additional parameters for the message payload that are available for the REST API. For more information check the [OneSignal documentation](https://documentation.onesignal.com/reference).
 
 ### Button usage
 

--- a/src/OneSignalMessage.php
+++ b/src/OneSignalMessage.php
@@ -27,6 +27,9 @@ class OneSignalMessage
     /** @var array */
     protected $webButtons = [];
 
+    /** @var array */
+    protected $extraParameters = [];
+
     /**
      * @param string $body
      *
@@ -117,6 +120,21 @@ class OneSignalMessage
     }
 
     /**
+     * Set additional parameters.
+     *
+     * @param string $key
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setParameter($key, $value)
+    {
+        $this->extraParameters[$key] = $value;
+
+        return $this;
+    }
+
+    /**
      * Add a web button to the message.
      *
      * @param OneSignalWebButton $button
@@ -160,6 +178,10 @@ class OneSignalMessage
             'adm_small_icon' => $this->icon,
             'small_icon' => $this->icon,
         ];
+
+        foreach ($this->extraParameters as $key => $value) {
+            Arr::set($message, $key, $value);
+        }
 
         foreach ($this->data as $data => $value) {
             Arr::set($message, 'data.'.$data, $value);


### PR DESCRIPTION
Adds a `setParameter` method to `OneSignalMessage` to allow the setting of any API parameter.

Example usage:

```
public function toOneSignal($notifiable)
{
        return OneSignalMessage::create()
            ->subject('Example')
            ->body('Example body')
            ->setParameter('ios_badgeType', 'Increase')
            ->setParameter('ios_badgeCount', 1);
}

```

Would fix https://github.com/laravel-notification-channels/onesignal/issues/16