### PR TITLE
Support for 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can install the package via composer:
 composer require laravel-notification-channels/onesignal
 ```
 
-You must install the service provider:
+This package supports Laravel >= 5.5 packages auto-discovery. For previous version, you must install the service provider:
 
 ```php
 // config/app.php

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OneSignal notifications channel for Laravel 5.3
+# OneSignal notifications channel for Laravel >= 5.3
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/onesignal.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/onesignal)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
@@ -9,7 +9,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/onesignal/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/onesignal/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/onesignal.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/onesignal)
 
-This package makes it easy to send [OneSignal notifications](https://documentation.onesignal.com/docs) with Laravel 5.3.
+This package makes it easy to send [OneSignal notifications](https://documentation.onesignal.com/docs) with Laravel >= 5.3.
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",
-        "orchestra/testbench": "3.3.x-dev",
-        "orchestra/database": "3.3.x-dev"
+        "orchestra/testbench": "3.5.x-dev",
+        "orchestra/database": "3.5.x-dev"
     },
     "autoload": {
         "psr-4": {
@@ -37,7 +37,7 @@
         }
     },
     "scripts": {
-        "test": "vendor/bin/phpunit"
+        "test": "phpunit"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "NotificationChannels\\OneSignal\\OneSignalServiceProvider"
+            ]
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     "require": {
         "php": ">=5.6.4",
         "berkayk/onesignal-laravel": "^0.9.3",
-        "illuminate/notifications": "5.3.*|5.4.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*"
+        "illuminate/notifications": "5.3.*|5.4.*|5.5.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -7,7 +7,7 @@ use NotificationChannels\OneSignal\OneSignalButton;
 use NotificationChannels\OneSignal\OneSignalMessage;
 use NotificationChannels\OneSignal\OneSignalWebButton;
 
-class MessageTest extends \PHPUnit_Framework_TestCase
+class MessageTest extends \PHPUnit\Framework\TestCase
 {
     /** @var \NotificationChannels\OneSignal\OneSignalMessage */
     protected $message;


### PR DESCRIPTION
Updated packages for 5.5 support, and added required lines for package auto-discovery.

Also made some small cosmetic change to the readme so it's clear that the package supports laravel >= 5.3.