### PR TITLE
Update travis to exclude php 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
 


### PR DESCRIPTION
It's the main reason behind not accepting #24 & #25 PRs