### PR TITLE
Update to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
+        "mockery/mockery": "^1.0",
         "orchestra/testbench": "3.3.x-dev",
         "orchestra/database": "3.3.x-dev"
     },


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).

PS: I won't apply [this](https://styleci.io/analyses/zOgWEB) StyleCI changes. There are not related to this PR :sweat_smile: 