### PR TITLE
Add setImageAttachments Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ public function routeNotificationForOneSignal()
 - `button(OneSignalButton $button)`: Allows you to add buttons to the notification (Supported by iOS 8.0 and Android 4.1+ devices. Icon only works for Android).
 - `setData($key, $value)`: Allows you to set additional data for the message payload. For more information check the [OneSignal documentation](https://documentation.onesignal.com/reference).
 - `setParameter($key, $value)`: Allows you to set additional parameters for the message payload that are available for the REST API. For more information check the [OneSignal documentation](https://documentation.onesignal.com/reference).
-
+- `setImageAttachments($imageUrl)`: Allows you to set one Image to all possible Attachments [OneSignal Attachment documentation](https://documentation.onesignal.com/reference#section-attachments).
 ### Button usage
 
 ```php

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ public function routeNotificationForOneSignal()
 - `setData($key, $value)`: Allows you to set additional data for the message payload. For more information check the [OneSignal documentation](https://documentation.onesignal.com/reference).
 - `setParameter($key, $value)`: Allows you to set additional parameters for the message payload that are available for the REST API. For more information check the [OneSignal documentation](https://documentation.onesignal.com/reference).
 - `setImageAttachments($imageUrl)`: Allows you to set one Image to all possible Attachments [OneSignal Attachment documentation](https://documentation.onesignal.com/reference#section-attachments).
+
 ### Button usage
 
 ```php

--- a/src/OneSignalMessage.php
+++ b/src/OneSignalMessage.php
@@ -168,7 +168,8 @@ class OneSignalMessage
      *
      * @return $this
      */
-    public function setImageAttachments($imageUrl){
+    public function setImageAttachments($imageUrl)
+    {
         $this->extraParameters['ios_attachments']['id1'] = $imageUrl;
         $this->extraParameters['big_picture'] = $imageUrl;
         $this->extraParameters['adm_big_picture'] = $imageUrl;

--- a/src/OneSignalMessage.php
+++ b/src/OneSignalMessage.php
@@ -163,6 +163,21 @@ class OneSignalMessage
     }
 
     /**
+     * Set an image to all possible attachment variables.
+     * @param string $imageUrl
+     *
+     * @return $this
+     */
+    public function setImageAttachments($imageUrl){
+        $this->extraParameters['ios_attachments']['id1'] = $imageUrl;
+        $this->extraParameters['big_picture'] = $imageUrl;
+        $this->extraParameters['adm_big_picture'] = $imageUrl;
+        $this->extraParameters['chrome_big_picture'] = $imageUrl;
+
+        return $this;
+    }
+
+    /**
      * @return array
      */
     public function toArray()

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -108,4 +108,14 @@ class MessageTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('buttonText', Arr::get($this->message->toArray(), 'buttons.0.text'));
         $this->assertEquals('buttonIcon', Arr::get($this->message->toArray(), 'buttons.0.icon'));
     }
+
+    /** @test */
+    public function it_can_set_a_image(){
+        $this->message->setImageAttachments('https://url.com/to/image.jpg');
+
+        $this->assertEquals('https://url.com/to/image.jpg',Arr::get($this->message->toArray(), 'ios_attachments.id1'));
+        $this->assertEquals('https://url.com/to/image.jpg',Arr::get($this->message->toArray(), 'big_picture'));
+        $this->assertEquals('https://url.com/to/image.jpg',Arr::get($this->message->toArray(), 'adm_big_picture'));
+        $this->assertEquals('https://url.com/to/image.jpg',Arr::get($this->message->toArray(), 'chrome_big_picture'));
+    }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -114,9 +114,9 @@ class MessageTest extends \PHPUnit\Framework\TestCase
     {
         $this->message->setImageAttachments('https://url.com/to/image.jpg');
 
-        $this->assertEquals('https://url.com/to/image.jpg',Arr::get($this->message->toArray(), 'ios_attachments.id1'));
-        $this->assertEquals('https://url.com/to/image.jpg',Arr::get($this->message->toArray(), 'big_picture'));
-        $this->assertEquals('https://url.com/to/image.jpg',Arr::get($this->message->toArray(), 'adm_big_picture'));
-        $this->assertEquals('https://url.com/to/image.jpg',Arr::get($this->message->toArray(), 'chrome_big_picture'));
+        $this->assertEquals('https://url.com/to/image.jpg', Arr::get($this->message->toArray(), 'ios_attachments.id1'));
+        $this->assertEquals('https://url.com/to/image.jpg', Arr::get($this->message->toArray(), 'big_picture'));
+        $this->assertEquals('https://url.com/to/image.jpg', Arr::get($this->message->toArray(), 'adm_big_picture'));
+        $this->assertEquals('https://url.com/to/image.jpg', Arr::get($this->message->toArray(), 'chrome_big_picture'));
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -110,7 +110,8 @@ class MessageTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @test */
-    public function it_can_set_a_image(){
+    public function it_can_set_a_image()
+    {
         $this->message->setImageAttachments('https://url.com/to/image.jpg');
 
         $this->assertEquals('https://url.com/to/image.jpg',Arr::get($this->message->toArray(), 'ios_attachments.id1'));


### PR DESCRIPTION
As suggested in #34 this is the new method for setting all possible image Attachments at the same time. 

After this PR you could simply to 

```php
$message->setImageAttachments('/path/or/url/to/image.jpg');
```
and it adds the URL to the needed properties. If you want to customize it more (e.g. set another Image for iOS as for Web Push) you should use the ``setParameter($key, $value);`` -Method