### PR TITLE
Return the response after sending the message

### DIFF
--- a/src/OneSignalChannel.php
+++ b/src/OneSignalChannel.php
@@ -29,7 +29,7 @@ class OneSignalChannel
     public function send($notifiable, Notification $notification)
     {
         if (! $userIds = $notifiable->routeNotificationFor('OneSignal')) {
-            return;
+            return null;
         }
 
         $payload = $notification->toOneSignal($notifiable)->toArray();

--- a/src/OneSignalChannel.php
+++ b/src/OneSignalChannel.php
@@ -29,7 +29,7 @@ class OneSignalChannel
     public function send($notifiable, Notification $notification)
     {
         if (! $userIds = $notifiable->routeNotificationFor('OneSignal')) {
-            return null;
+            return;
         }
 
         $payload = $notification->toOneSignal($notifiable)->toArray();

--- a/src/OneSignalChannel.php
+++ b/src/OneSignalChannel.php
@@ -23,6 +23,7 @@ class OneSignalChannel
      * @param mixed $notifiable
      * @param \Illuminate\Notifications\Notification $notification
      *
+     * @return \Psr\Http\Message\ResponseInterface
      * @throws \NotificationChannels\OneSignal\Exceptions\CouldNotSendNotification
      */
     public function send($notifiable, Notification $notification)
@@ -45,5 +46,7 @@ class OneSignalChannel
         if ($response->getStatusCode() !== 200) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);
         }
+
+        return $response;
     }
 }

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -6,9 +6,9 @@ use Mockery;
 use GuzzleHttp\Psr7\Response;
 use Orchestra\Testbench\TestCase;
 use Berkayk\OneSignal\OneSignalClient;
+use Psr\Http\Message\ResponseInterface;
 use NotificationChannels\OneSignal\OneSignalChannel;
 use NotificationChannels\OneSignal\Exceptions\CouldNotSendNotification;
-use Psr\Http\Message\ResponseInterface;
 
 class ChannelTest extends TestCase
 {

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -8,6 +8,7 @@ use Orchestra\Testbench\TestCase;
 use Berkayk\OneSignal\OneSignalClient;
 use NotificationChannels\OneSignal\OneSignalChannel;
 use NotificationChannels\OneSignal\Exceptions\CouldNotSendNotification;
+use Psr\Http\Message\ResponseInterface;
 
 class ChannelTest extends TestCase
 {
@@ -52,7 +53,9 @@ class ChannelTest extends TestCase
             ])
             ->andReturn($response);
 
-        $this->channel->send(new Notifiable(), new TestNotification());
+        $channel_response = $this->channel->send(new Notifiable(), new TestNotification());
+
+        $this->assertInstanceOf(ResponseInterface::class, $channel_response);
     }
 
     /** @test */
@@ -104,6 +107,18 @@ class ChannelTest extends TestCase
             ])
             ->andReturn($response);
 
-        $this->channel->send(new NotifiableEmail(), new TestNotification());
+        $channel_response = $this->channel->send(new NotifiableEmail(), new TestNotification());
+
+        $this->assertInstanceOf(ResponseInterface::class, $channel_response);
+    }
+
+    /** @test */
+    public function it_sends_nothing_and_returns_null_when_player_id_empty()
+    {
+        $this->oneSignal->shouldReceive('sendNotificationCustom')
+            ->never();
+
+        $channel_response = $this->channel->send(new EmptyNotifiable(), new TestNotification());
+        $this->assertNull($channel_response);
     }
 }

--- a/tests/EmptyNotifiable.php
+++ b/tests/EmptyNotifiable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NotificationChannels\OneSignal\Test;
+
+class EmptyNotifiable
+{
+    use \Illuminate\Notifications\Notifiable;
+
+    /**
+     * @return int
+     */
+    public function routeNotificationForOneSignal()
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
Laravel's notification sender (`Illuminate\Notifications\NotificationSender`) dispatches an event (`Illuminate\Notifications\Events\NotificationSent`) after the message has been sent.
This event contains the response returned from the specific notification channel. When no response is returned, this event's response attribute contains `null`.

However, this information could be useful - for logging purposes, for pairing the notification messages with the users etc.