### PR TITLE
Add player id array test

### DIFF
--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -87,6 +87,34 @@ class ChannelTest extends TestCase
     /**
      * @test
      */
+    public function it_can_send_a_notification_with_array()
+    {
+        $response = new Response(200);
+
+        $this->oneSignal->shouldReceive('sendNotificationCustom')
+            ->once()
+            ->with([
+                'contents' => ['en' => 'Body'],
+                'headings' => ['en' => 'Subject'],
+                'url' => 'URL',
+                'buttons' => [],
+                'web_buttons' => [],
+                'chrome_web_icon' => 'Icon',
+                'chrome_icon' => 'Icon',
+                'adm_small_icon' => 'Icon',
+                'small_icon' => 'Icon',
+                'include_player_ids' => collect(['player_id_1', 'player_id_2']),
+            ])
+            ->andReturn($response);
+
+        $channel_response = $this->channel->send(new NotifiableArray(), new TestNotification());
+
+        $this->assertInstanceOf(ResponseInterface::class, $channel_response);
+    }
+
+    /**
+     * @test
+     */
     public function it_can_send_a_notification_with_email()
     {
         $response = new Response(200);

--- a/tests/NotifiableArray.php
+++ b/tests/NotifiableArray.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NotificationChannels\OneSignal\Test;
+
+class NotifiableArray
+{
+    use \Illuminate\Notifications\Notifiable;
+
+    /**
+     * @return int
+     */
+    public function routeNotificationForOneSignal()
+    {
+        return ['player_id_1', 'player_id_2'];
+    }
+}


### PR DESCRIPTION
Currently the docs specify that you can pass a single player id from a notifiable or an array of them. There was no test for an array...so I added one!