### PR TITLE
Add payload factory

### DIFF
--- a/src/OneSignalChannel.php
+++ b/src/OneSignalChannel.php
@@ -32,18 +32,6 @@ class OneSignalChannel
             return;
         }
 
-        $payload = $notification->toOneSignal($notifiable)->toArray();
-
-        if (is_array($userIds)) {
-            if (array_key_exists('email', $userIds)) {
-                $payload['filters'] = collect([['field' => 'email', 'value' => $userIds['email']]]);
-            } elseif (array_key_exists('tags', $userIds)) {
-                $payload['tags'] = collect([$userIds['tags']]);
-            }
-        } else {
-            $payload['include_player_ids'] = collect($userIds);
-        }
-
         /** @var ResponseInterface $response */
         $response = $this->oneSignal->sendNotificationCustom(
             $this->payload($notifiable, $notification, $userIds)

--- a/src/OneSignalChannel.php
+++ b/src/OneSignalChannel.php
@@ -44,6 +44,13 @@ class OneSignalChannel
         return $response;
     }
 
+    /**
+     * @param mixed $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     * @param mixed $targeting
+     *
+     * @return array
+     */
     protected function payload($notifiable, $notification, $userIds)
     {
         return OneSignalPayloadFactory::make($notifiable, $notification, $userIds);

--- a/src/OneSignalChannel.php
+++ b/src/OneSignalChannel.php
@@ -32,21 +32,20 @@ class OneSignalChannel
             return;
         }
 
-        $payload = $notification->toOneSignal($notifiable)->toArray();
-
-        if (is_array($userIds) && array_key_exists('email', $userIds)) {
-            $payload['filters'] = collect([['field' => 'email', 'value' => $userIds['email']]]);
-        } else {
-            $payload['include_player_ids'] = collect($userIds);
-        }
-
         /** @var ResponseInterface $response */
-        $response = $this->oneSignal->sendNotificationCustom($payload);
+        $response = $this->oneSignal->sendNotificationCustom(
+            $this->payload($notifiable, $notification, $userIds)
+        );
 
         if ($response->getStatusCode() !== 200) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);
         }
 
         return $response;
+    }
+
+    protected function payload($notifiable, $notification, $userIds)
+    {
+        return OneSignalPayloadFactory::make($notifiable, $notification, $userIds);
     }
 }

--- a/src/OneSignalPayloadFactory.php
+++ b/src/OneSignalPayloadFactory.php
@@ -21,6 +21,8 @@ class OneSignalPayloadFactory
 
         if (static::isTargetingEmail($targeting)) {
             $payload['filters'] = collect([['field' => 'email', 'value' => $targeting['email']]]);
+        } elseif (static::isTargetingTags($targeting)) {
+            $payload['tags'] = collect([$targeting['tags']]);
         } else {
             $payload['include_player_ids'] = collect($targeting);
         }
@@ -36,5 +38,10 @@ class OneSignalPayloadFactory
     protected static function isTargetingEmail($targeting)
     {
         return is_array($targeting) && array_key_exists('email', $targeting);
+    }
+
+    protected static function isTargetingTags($targeting)
+    {
+        return is_array($targeting) && array_key_exists('tags', $targeting);
     }
 }

--- a/src/OneSignalPayloadFactory.php
+++ b/src/OneSignalPayloadFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace NotificationChannels\OneSignal;
+
+use Illuminate\Notifications\Notification;
+
+class OneSignalPayloadFactory
+{
+    /**
+     * Make a one signal notification payload.
+     *
+     * @param mixed $notifiable
+     * @param \Illuminate\Notifications\Notification $notification
+     * @param mixed $targeting
+     *
+     * @return array
+     */
+    public static function make($notifiable, Notification $notification, $targeting) : array
+    {
+        $payload = $notification->toOneSignal($notifiable)->toArray();
+
+        if (static::isTargetingEmail($targeting)) {
+            $payload['filters'] = collect([['field' => 'email', 'value' => $targeting['email']]]);
+        } else {
+            $payload['include_player_ids'] = collect($targeting);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param mixed $targeting
+     *
+     * @return bool
+     */
+    protected static function isTargetingEmail($targeting)
+    {
+        return is_array($targeting) && array_key_exists('email', $targeting);
+    }
+}


### PR DESCRIPTION
I've added a basic factory to run through the payload logic. This will keep all the logic around what the notification is targeting in one place e.g. emails, player ids, and [soon tags](https://github.com/laravel-notification-channels/onesignal/pull/48) + whatever else may be added in the future.

I've added the `payload` method to the channel class so devs can still easily extend the channel and add future payload functionality that might not yet be implemented - rather than introducing Interfaces etc for the factory. Keeping it simpler.