### PR TITLE
Remove return type

### DIFF
--- a/src/OneSignalPayloadFactory.php
+++ b/src/OneSignalPayloadFactory.php
@@ -15,7 +15,7 @@ class OneSignalPayloadFactory
      *
      * @return array
      */
-    public static function make($notifiable, Notification $notification, $targeting) : array
+    public static function make($notifiable, Notification $notification, $targeting)
     {
         $payload = $notification->toOneSignal($notifiable)->toArray();
 


### PR DESCRIPTION
I thought this whole project had return types, but turns out I added the only one. I removed it for consistency throughout the codebase.