### PR TITLE
Add iOS badge helpers

### DIFF
--- a/src/OneSignalMessage.php
+++ b/src/OneSignalMessage.php
@@ -105,6 +105,45 @@ class OneSignalMessage
     }
 
     /**
+     * Set the iOS badge increment count.
+     *
+     * @param int $count
+     *
+     * @return $this
+     */
+    public function incrementBadgeCount($count = 1)
+    {
+        return $this->setParameter('ios_badgeType', 'Increase')
+                    ->setParameter('ios_badgeCount', $count);
+    }
+
+    /**
+     * Set the iOS badge decrement count.
+     *
+     * @param int $count
+     *
+     * @return $this
+     */
+    public function decrementBadgeCount($count = 1)
+    {
+        return $this->setParameter('ios_badgeType', 'Increase')
+                    ->setParameter('ios_badgeCount', -1 * $count);
+    }
+
+    /**
+     * Set the iOS badge count.
+     *
+     * @param int $count
+     *
+     * @return $this
+     */
+    public function setBadgeCount($count)
+    {
+        return $this->setParameter('ios_badgeType', 'SetTo')
+                    ->setParameter('ios_badgeCount', $count);
+    }
+
+    /**
      * Set additional data.
      *
      * @param string $key

--- a/src/OneSignalMessage.php
+++ b/src/OneSignalMessage.php
@@ -111,7 +111,7 @@ class OneSignalMessage
      *
      * @return $this
      */
-    public function incrementBadgeCount($count = 1)
+    public function incrementIosBadgeCount($count = 1)
     {
         return $this->setParameter('ios_badgeType', 'Increase')
                     ->setParameter('ios_badgeCount', $count);
@@ -124,7 +124,7 @@ class OneSignalMessage
      *
      * @return $this
      */
-    public function decrementBadgeCount($count = 1)
+    public function decrementIosBadgeCount($count = 1)
     {
         return $this->setParameter('ios_badgeType', 'Increase')
                     ->setParameter('ios_badgeCount', -1 * $count);
@@ -137,7 +137,7 @@ class OneSignalMessage
      *
      * @return $this
      */
-    public function setBadgeCount($count)
+    public function setIosBadgeCount($count)
     {
         return $this->setParameter('ios_badgeType', 'SetTo')
                     ->setParameter('ios_badgeCount', $count);

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -59,6 +59,33 @@ class MessageTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @test */
+    public function it_can_set_the_increment_badge_count()
+    {
+        $this->message->incrementBadgeCount(123);
+
+        $this->assertEquals('Increase', Arr::get($this->message->toArray(), 'ios_badgeType'));
+        $this->assertEquals(123, Arr::get($this->message->toArray(), 'ios_badgeCount'));
+    }
+
+    /** @test */
+    public function it_can_set_the_decrement_badge_count()
+    {
+        $this->message->decrementBadgeCount(123);
+
+        $this->assertEquals('Increase', Arr::get($this->message->toArray(), 'ios_badgeType'));
+        $this->assertEquals(-123, Arr::get($this->message->toArray(), 'ios_badgeCount'));
+    }
+
+    /** @test */
+    public function it_can_set_the_badge_count()
+    {
+        $this->message->setBadgeCount(123);
+
+        $this->assertEquals('SetTo', Arr::get($this->message->toArray(), 'ios_badgeType'));
+        $this->assertEquals(123, Arr::get($this->message->toArray(), 'ios_badgeCount'));
+    }
+
+    /** @test */
     public function it_can_set_additional_data()
     {
         $this->message->setData('key_one', 'value_one');

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -61,7 +61,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_can_set_the_increment_badge_count()
     {
-        $this->message->incrementBadgeCount(123);
+        $this->message->incrementIosBadgeCount(123);
 
         $this->assertEquals('Increase', Arr::get($this->message->toArray(), 'ios_badgeType'));
         $this->assertEquals(123, Arr::get($this->message->toArray(), 'ios_badgeCount'));
@@ -70,7 +70,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_can_set_the_decrement_badge_count()
     {
-        $this->message->decrementBadgeCount(123);
+        $this->message->decrementIosBadgeCount(123);
 
         $this->assertEquals('Increase', Arr::get($this->message->toArray(), 'ios_badgeType'));
         $this->assertEquals(-123, Arr::get($this->message->toArray(), 'ios_badgeCount'));
@@ -79,7 +79,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
     /** @test */
     public function it_can_set_the_badge_count()
     {
-        $this->message->setBadgeCount(123);
+        $this->message->setIosBadgeCount(123);
 
         $this->assertEquals('SetTo', Arr::get($this->message->toArray(), 'ios_badgeType'));
         $this->assertEquals(123, Arr::get($this->message->toArray(), 'ios_badgeCount'));


### PR DESCRIPTION
Added a few helper methods to help deal with badge counts on iOS. Note that these *only apply* to iOS - as OneSignal does not allow badge counts on Android.

From the docs:
```
Badges - shows the number of notifications outstanding. Note: Android badges are automatically handled by OneSignal.

// source: https://documentation.onesignal.com/reference#section-appearance
```

I doubt you want to add methods for every parameter, but I thought this was a good candidate because it's not just key / value, but a couple of key / values to get it working. Tripped me up for a minute and thought it might help others in the future.