### PR TITLE
Allow an empty subject

### DIFF
--- a/src/OneSignalMessage.php
+++ b/src/OneSignalMessage.php
@@ -185,7 +185,7 @@ class OneSignalMessage
     {
         $message = [
             'contents' => ['en' => $this->body],
-            'headings' => ['en' => $this->subject],
+            'headings' => $this->subjectToArray(),
             'url' => $this->url,
             'buttons' => $this->buttons,
             'web_buttons' => $this->webButtons,
@@ -204,5 +204,14 @@ class OneSignalMessage
         }
 
         return $message;
+    }
+
+    protected function subjectToArray()
+    {
+        if ($this->subject === null) {
+            return [];
+        }
+
+        return ['en' => $this->subject];
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -51,6 +51,12 @@ class MessageTest extends \PHPUnit\Framework\TestCase
     }
 
     /** @test */
+    public function it_does_not_append_empty_subject_value_when_subject_is_null()
+    {
+        $this->assertEquals([], Arr::get($this->message->toArray(), 'headings'));
+    }
+
+    /** @test */
     public function it_can_set_the_url()
     {
         $this->message->url('myURL');


### PR DESCRIPTION
The only required parameter of the `OneSignalMessage` should be the body / contents. However, due to how the subject was previously added in the `toArray()` method, OneSignal would throw an error due to an empty subject.

Let's see some code.

```php
public function toOneSignal($notifiable)
{
    return OneSignalMessage::create()
        ->body($this->content($notifiable))
        ->setParameter('ios_badgeCount', 1)
        ->setParameter('mutable_content', true)
        ->setParameter('ios_badgeType', 'Increase')
        ->setParameter('ios_category', $this->iosCategory($notifiable))
        ->setParameter('android_group', $this->androidGroup($notifiable));
}
```

Here you can see I am not setting the subject. Now let's look at the `toArray()` method:

```php
public function toArray()
{
    $message = [
        'contents' => ['en' => $this->body],
        'headings' => ['en' => $this->subject],
        // "headings" => ["en" => null]

```
OneSignal throws an error if you provide an empty value for the subject as above:
```
[2018-03-13 02:36:57] local.ERROR: Client error: `POST https://onesignal.com/api/v1/notifications` resulted in a `400 Bad Request` response:
{"errors":["Notification headings must not be null for any languages."]}
 {"exception":"[object] (GuzzleHttp\\Exception\\ClientException(code: 400): Client error: `POST https://onesignal.com/api/v1/notifications` resulted in a `400 Bad Request` response:
{\"errors\":[\"Notification headings must not be null for any languages.\"]}
 at /Users/tim/Documents/Gits/APP_NAME/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php:113)
[stacktrace]
...
```

This PR implements a new method called `subjectToArray()` which will only return the language / value key pair if there is a subject set - otherwise an empty array is returned. This fixes the above OneSignal error.