### PR TITLE
Pass the notification object to the routeNotificationFor method

### DIFF
--- a/src/OneSignalChannel.php
+++ b/src/OneSignalChannel.php
@@ -28,7 +28,7 @@ class OneSignalChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $userIds = $notifiable->routeNotificationFor('OneSignal')) {
+        if (! $userIds = $notifiable->routeNotificationFor('OneSignal', $notification)) {
             return;
         }
 


### PR DESCRIPTION
This allows the developer to access the notification here:
```
public function routeNotificationForOneSignal(Notification $notification)
{
    // access $notification here
}
```