### PR TITLE
minimalistic silent push notification support

### DIFF
--- a/src/OneSignalMessage.php
+++ b/src/OneSignalMessage.php
@@ -223,8 +223,6 @@ class OneSignalMessage
     public function toArray()
     {
         $message = [
-            'contents' => ['en' => $this->body],
-            'headings' => $this->subjectToArray(),
             'url' => $this->url,
             'buttons' => $this->buttons,
             'web_buttons' => $this->webButtons,
@@ -233,13 +231,20 @@ class OneSignalMessage
             'adm_small_icon' => $this->icon,
             'small_icon' => $this->icon,
         ];
+        if($this->body)
+            $message['contents']['en'] = $this->body;
+        if($this->subject)
+            $message['headings']['en'] = $this->subject;
 
         foreach ($this->extraParameters as $key => $value) {
             Arr::set($message, $key, $value);
         }
 
-        foreach ($this->data as $data => $value) {
-            Arr::set($message, 'data.'.$data, $value);
+        if(count($this->data) > 0) {
+            foreach ($this->data as $data => $value) {
+                Arr::set($message, 'data.'.$data, $value);
+            }
+            Arr::set($message, 'content_available', 1);
         }
 
         return $message;


### PR DESCRIPTION
Made a small change to enable sending push notifications without body and subject (ie silent push notifications). Also forced the content_available parameter, if data is set, but Im not sure if thats needed since I could use "setParameter" to do that. 

The "real" implementation should probably be to add a "setSilent" method and adjust the payload accordingly. 

Good enough?
