### PR TITLE
Add support for silent messages

### DIFF
--- a/src/OneSignalMessage.php
+++ b/src/OneSignalMessage.php
@@ -4,14 +4,14 @@ namespace NotificationChannels\OneSignal;
 
 use Illuminate\Support\Arr;
 use NotificationChannels\OneSignal\Traits\{
-    Categories\AppearanceHelpers, Categories\AttachmentHelpers, Categories\ButtonHelpers, Categories\DeliveryHelpers, Categories\GroupingHelpers, Deprecated
+    Categories\AppearanceHelpers, Categories\AttachmentHelpers, Categories\ButtonHelpers, Categories\DeliveryHelpers, Categories\GroupingHelpers, Categories\SilentHelpers, Deprecated
 };
 
 
 class OneSignalMessage
 {
 
-    use AppearanceHelpers, AttachmentHelpers, ButtonHelpers, DeliveryHelpers, GroupingHelpers, Deprecated;
+    use AppearanceHelpers, AttachmentHelpers, ButtonHelpers, DeliveryHelpers, GroupingHelpers, SilentHelpers, Deprecated;
 
     /** @var array */
     protected $payload = [];

--- a/src/Traits/Categories/SilentHelpers.php
+++ b/src/Traits/Categories/SilentHelpers.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace NotificationChannels\OneSignal\Traits\Categories;
+use Illuminate\Support\Arr;
+
+trait SilentHelpers
+{
+    /**
+     * Enables silent mode
+     *
+     * @return $this
+     */
+    public function setSilent()
+    {
+        Arr::forget($this->payload, 'contents'); //removes any contents that are set by constructor.
+        return $this->setParameter('content_available', 1);
+    }
+}

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -165,4 +165,23 @@ class ChannelTest extends TestCase
         $channel_response = $this->channel->send(new EmptyNotifiable(), new TestNotification());
         $this->assertNull($channel_response);
     }
+
+    public function it_can_send_a_silent_notification()
+    {
+        $response = new Response(200);
+
+        $this->oneSignal->shouldReceive('sendNotificationCustom')
+            ->once()
+            ->with([
+                'content_available' => 1,
+                'data.action' => 'reload',
+                'data.target' => 'inbox',
+                'include_player_ids' => collect('player_id'),
+            ])
+            ->andReturn($response);
+
+        $channel_response = $this->channel->send(new Notifiable(), new TestSilentNotification());
+
+        $this->assertInstanceOf(ResponseInterface::class, $channel_response);
+    }
 }

--- a/tests/TestSilentNotification.php
+++ b/tests/TestSilentNotification.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace NotificationChannels\OneSignal\Test;
+
+use Illuminate\Notifications\Notification;
+use NotificationChannels\OneSignal\OneSignalMessage;
+
+class TestSilentNotification extends Notification
+{
+    public function toOneSignal($notifiable)
+    {
+        return (new OneSignalMessage())
+            ->setSilent()
+            ->setData('action', 'reload')
+            ->setData('target', 'inbox');
+    }
+}


### PR DESCRIPTION
A defensive change in message class adding support for silent push notifications (in the traits branch now).