### PR TITLE
Add alias for notification channel

### DIFF
--- a/src/OneSignalServiceProvider.php
+++ b/src/OneSignalServiceProvider.php
@@ -4,6 +4,7 @@ namespace NotificationChannels\OneSignal;
 
 use Berkayk\OneSignal\OneSignalClient;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Notification;
 use NotificationChannels\OneSignal\Exceptions\InvalidConfiguration;
 
 class OneSignalServiceProvider extends ServiceProvider
@@ -13,20 +14,26 @@ class OneSignalServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $oneSignalClient = new OneSignalClient(
+            config('services.onesignal.app_id'),
+            config('services.onesignal.rest_api_key'),
+            ''
+        );
+
+        Notification::extend('onesignal', function () use ($oneSignalClient) {
+            return new OneSignalChannel($oneSignalClient);
+        });
+
         $this->app->when(OneSignalChannel::class)
             ->needs(OneSignalClient::class)
-            ->give(function () {
-                $oneSignalConfig = config('services.onesignal');
+            ->give(function () use ($oneSignalClient) {
+                $oneSignalConfig = $this->app['config']->get('services.onesignal');
 
                 if (is_null($oneSignalConfig)) {
                     throw InvalidConfiguration::configurationNotSet();
                 }
 
-                return new OneSignalClient(
-                    $oneSignalConfig['app_id'],
-                    $oneSignalConfig['rest_api_key'],
-                    ''
-                );
+                return $oneSignalClient;
             });
     }
 }


### PR DESCRIPTION
This PR. allows to use `onesignal` instead of `OneSignalChannel::class` in via method.
Ex : 
```
/**
 * Get the notification's delivery channels.
 *
 * @param  mixed $notifiable
 * @return array
 */
public function via($notifiable)
{
    return ['onesignal'];
}
```