### PR TITLE
Target external user IDs

### DIFF
--- a/src/OneSignalPayloadFactory.php
+++ b/src/OneSignalPayloadFactory.php
@@ -33,6 +33,8 @@ class OneSignalPayloadFactory
             $payload['included_segments'] = collect($targeting['included_segments']);
         } elseif (static::isTargetingExcludedSegments($targeting)) {
             $payload['excluded_segments'] = collect($targeting['excluded_segments']);
+        } elseif (static::isTargetingExternalUserIds($targeting)) {
+            $payload['include_external_user_ids'] = collect($targeting);
         } else {
             $payload['include_player_ids'] = collect($targeting);
         }
@@ -48,6 +50,16 @@ class OneSignalPayloadFactory
     protected static function isTargetingIncludedSegments($targeting)
     {
         return is_array($targeting) && array_key_exists('included_segments', $targeting);
+    }
+
+    /**
+     * @param mixed $targeting
+     *
+     * @return bool
+     */
+    protected static function isTargetingExternalUserIds($targeting)
+    {
+        return is_array($targeting) && array_key_exists('include_external_user_ids', $targeting);
     }
 
     /**

--- a/src/OneSignalPayloadFactory.php
+++ b/src/OneSignalPayloadFactory.php
@@ -34,7 +34,7 @@ class OneSignalPayloadFactory
         } elseif (static::isTargetingExcludedSegments($targeting)) {
             $payload['excluded_segments'] = collect($targeting['excluded_segments']);
         } elseif (static::isTargetingExternalUserIds($targeting)) {
-            $payload['include_external_user_ids'] = collect($targeting);
+            $payload['include_external_user_ids'] = collect($targeting['include_external_user_ids']);
         } else {
             $payload['include_player_ids'] = collect($targeting);
         }

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -235,6 +235,32 @@ class ChannelTest extends TestCase
         $this->assertInstanceOf(ResponseInterface::class, $channel_response);
     }
 
+    /**
+     * @test
+     */
+    public function it_can_send_a_notification_with_external_ids()
+    {
+        $response = new Response(200);
+
+        $this->oneSignal->shouldReceive('sendNotificationCustom')
+            ->once()
+            ->with([
+                'contents'                  => ['en' => 'Body'],
+                'headings'                  => ['en' => 'Subject'],
+                'url'                       => 'URL',
+                'chrome_web_icon'           => 'Icon',
+                'chrome_icon'               => 'Icon',
+                'adm_small_icon'            => 'Icon',
+                'small_icon'                => 'Icon',
+                'include_external_user_ids' => collect(['external_id']),
+            ])
+            ->andReturn($response);
+
+        $channel_response = $this->channel->send(new NotifiableIncludesExternalIds(), new TestNotification());
+
+        $this->assertInstanceOf(ResponseInterface::class, $channel_response);
+    }
+
     /** @test */
     public function it_sends_nothing_and_returns_null_when_player_id_empty()
     {

--- a/tests/NotifiableIncludesExternalIds.php
+++ b/tests/NotifiableIncludesExternalIds.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace NotificationChannels\OneSignal\Test;
+
+class NotifiableIncludesExternalIds
+{
+    use \Illuminate\Notifications\Notifiable;
+
+    /**
+     * @return array
+     */
+    public function routeNotificationForOneSignal()
+    {
+        return ['include_external_user_ids' => ['external_id']];
+    }
+}


### PR DESCRIPTION
A small change that allows you to send notifications to users by specifying an external user ID.

See the [OneSignal docs](https://documentation.onesignal.com/reference#section-send-to-specific-devices) under 'include_external_user_ids' for all the details.