### PR TITLE
Fix for sending notifications with include_external_user_ids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "berkayk/onesignal-laravel": "^1.0.0",
-        "illuminate/notifications": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0",
-        "illuminate/support": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0"
+        "berkayk/onesignal-laravel": "^1.0|^2.0",
+        "illuminate/notifications": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3|^1.4",

--- a/src/OneSignalPayloadFactory.php
+++ b/src/OneSignalPayloadFactory.php
@@ -35,6 +35,7 @@ class OneSignalPayloadFactory
             $payload['excluded_segments'] = collect($targeting['excluded_segments']);
         } elseif (static::isTargetingExternalUserIds($targeting)) {
             $payload['include_external_user_ids'] = collect($targeting['include_external_user_ids']);
+            $payload['channel_for_external_user_ids'] = 'push';
         } else {
             $payload['include_player_ids'] = collect($targeting);
         }


### PR DESCRIPTION
I was having an issue when using include_external_user_ids; The OneSignal API was returning an error: `Platforms You may only send to one delivery channel at a time. Make sure you are only including one of push platforms, isEmail, or isSms.`

This is fixed by setting channel_for_external_user_ids to Push, so the API knows which players to send.

This is a quick fix, but could possibly be made configurable.