### PR TITLE
Add support for berkayk/onesignal-laravel 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "berkayk/onesignal-laravel": "^1.0.0",
+        "berkayk/onesignal-laravel": "^1.0.0|^2.0",
         "illuminate/notifications": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0",
         "illuminate/support": "5.*|^6.0|^7.0|^8.0|^9.0|^10.0"
     },


### PR DESCRIPTION
This PR allows this package to be installed under Laravel 10.

The new release is tagged under `v2` with Laravel 10 compatibility: https://github.com/berkayk/laravel-onesignal/issues/178