### PR TITLE
Update service provider to match signature of berkayk package

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Add your OneSignal App ID and REST API Key to your `config/services.php`:
 ...
 'onesignal' => [
     'app_id' => env('ONESIGNAL_APP_ID'),
+    'rest_api_url' => env('ONESIGNAL_REST_API_URL', 'https://api.onesignal.com'),
     'rest_api_key' => env('ONESIGNAL_REST_API_KEY'),
     'guzzle_client_timeout' => env('ONESIGNAL_GUZZLE_CLIENT_TIMEOUT', 0),
 ],

--- a/src/OneSignalServiceProvider.php
+++ b/src/OneSignalServiceProvider.php
@@ -24,6 +24,7 @@ class OneSignalServiceProvider extends ServiceProvider
 
                 return new OneSignalClient(
                     $oneSignalConfig['app_id'],
+                    $oneSignalConfig['rest_api_url'] ?? 'https://api.onesignal.com',
                     $oneSignalConfig['rest_api_key'],
                     ''
                 );


### PR DESCRIPTION
The underlying berkayk/laravel-onesignal package updated from 2.2 to 2.3 and had a breaking change in the service provider implementation. There is a new API key that needs to be set as the 2nd argument. That inherently broke this package.

This PR updates the Service Provider argument signature to include the new API requirement. I've also updated the readme to tell users that they can set it in the config. 

Right now I have it looking for the config value or falling back to a hard-coded `https://api.onesignal.com` which is the new API endpoint that OneSignal is using. The old `https://onesignal.com/api/v1/` will be deprecated of March 1, 2025.

Troublesome Release: https://github.com/berkayk/laravel-onesignal/releases/tag/v2.3
Closes: #155 